### PR TITLE
Set up public & private ELBs for gateway instances

### DIFF
--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -293,6 +293,7 @@
         "z": 1,
         "embeds": [
           "1cc85fdc-e298-4914-849e-7a7f18364e85",
+          "4382883d-ccbb-4b33-934c-19e73f682e7f",
           "314120e5-87bf-4791-80ae-cd443fad4186",
           "4719e386-5f75-42ec-9fb2-91f8386f9f87",
           "317ab59f-2379-451a-9fbc-c397fd31dd5c",
@@ -822,7 +823,8 @@
         "embeds": [],
         "isconnectedto": [
           "f591c362-5976-4efe-aca1-f1c0cb9f31af",
-          "1bbd2641-5532-431b-a1dd-a7dd893e58db"
+          "1bbd2641-5532-431b-a1dd-a7dd893e58db",
+          "1d4a5fec-f915-4f8b-afef-87442f63ecec"
         ],
         "isassociatedwith": [
           "428b2995-219a-422e-a4b6-bc7c91ff2828"
@@ -886,13 +888,13 @@
           "id": "251f6d10-84e4-44a1-b93e-67bbe9078fba"
         },
         "target": {
-          "id": "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0"
+          "id": "4382883d-ccbb-4b33-934c-19e73f682e7f"
         },
         "z": 0
       },
       "9fca00aa-30f9-4b28-9fdc-5459f77dabc2": {
         "source": {
-          "id": "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0"
+          "id": "4382883d-ccbb-4b33-934c-19e73f682e7f"
         },
         "target": {
           "id": "4719e386-5f75-42ec-9fb2-91f8386f9f87"
@@ -1047,6 +1049,68 @@
           "id": "1bbd2641-5532-431b-a1dd-a7dd893e58db"
         },
         "z": 11
+      },
+      "1d4a5fec-f915-4f8b-afef-87442f63ecec": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": -170,
+          "y": 400
+        },
+        "z": 0,
+        "embeds": [],
+        "isconnectedto": [
+          "f591c362-5976-4efe-aca1-f1c0cb9f31af",
+          "314120e5-87bf-4791-80ae-cd443fad4186"
+        ],
+        "ismemberof": [
+          "317ab59f-2379-451a-9fbc-c397fd31dd5c",
+          "255d4787-f655-4580-a914-8fddeba1bc2d"
+        ]
+      },
+      "255d4787-f655-4580-a914-8fddeba1bc2d": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": -170,
+          "y": 290
+        },
+        "z": 0,
+        "embeds": []
+      },
+      "a0ca15e0-b8a8-400b-b8b8-162577e7cc60": {
+        "source": {
+          "id": "1d4a5fec-f915-4f8b-afef-87442f63ecec"
+        },
+        "target": {
+          "id": "255d4787-f655-4580-a914-8fddeba1bc2d"
+        },
+        "z": 11
+      },
+      "74839bc6-9b1d-46ae-94d1-eb5302f132a6": {
+        "source": {
+          "id": "4cd01314-51ae-4fac-9c95-36004183543b",
+          "selector": "g:nth-child(1) g:nth-child(4) g:nth-child(1) circle:nth-child(1)     ",
+          "port": "AWS::EC2::SecurityGroupIngress"
+        },
+        "target": {
+          "x": -150,
+          "y": 310
+        },
+        "z": 12
+      },
+      "d8239a35-58e3-4723-adf3-f524c1f86af9": {
+        "source": {
+          "id": "4cd01314-51ae-4fac-9c95-36004183543b"
+        },
+        "target": {
+          "id": "255d4787-f655-4580-a914-8fddeba1bc2d"
+        },
+        "z": 0
       }
     }
   },
@@ -2360,6 +2424,9 @@
         "LoadBalancerNames": [
           {
             "Ref": "GatewayPublicELB"
+          },
+          {
+            "Ref": "GatewayPrivateELB"
           }
         ]
       },
@@ -2616,6 +2683,83 @@
       "Metadata": {
         "AWS::CloudFormation::Designer": {
           "id": "1cc85fdc-e298-4914-849e-7a7f18364e85"
+        }
+      }
+    },
+    "GatewayPrivateELB": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "Scheme": "internal",
+        "Subnets": [
+          {
+            "Ref": "ControllerSubnet"
+          }
+        ],
+        "SecurityGroups": [
+          {
+            "Ref": "GatewayPrivateELBSecurityGroup"
+          }
+        ],
+        "Listeners": [
+          {
+            "InstancePort": 7331,
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": 80,
+            "Protocol": "TCP"
+          }
+        ],
+        "HealthCheck": {
+          "Target": "TCP:7331",
+          "HealthyThreshold": "2",
+          "Interval": "6",
+          "Timeout": "5",
+          "UnhealthyThreshold": "2"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "1d4a5fec-f915-4f8b-afef-87442f63ecec"
+        }
+      }
+    },
+    "GatewayPrivateELBSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "GatewayPrivateELBSecurityGroup",
+        "VpcId": {
+          "Ref": "ClusterVPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "TCP",
+            "FromPort": 80,
+            "ToPort": 80,
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "255d4787-f655-4580-a914-8fddeba1bc2d"
+        }
+      }
+    },
+    "ControllerSecurityGroupIngressFromGatewayPrivateELB": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "ControllerSecurityGroup"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "GatewayPrivateELBSecurityGroup"
+        },
+        "FromPort": 7331,
+        "ToPort": 7331,
+        "IpProtocol": "TCP"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "d8239a35-58e3-4723-adf3-f524c1f86af9"
         }
       }
     }

--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -292,9 +292,10 @@
         },
         "z": 1,
         "embeds": [
-          "4382883d-ccbb-4b33-934c-19e73f682e7f",
+          "1cc85fdc-e298-4914-849e-7a7f18364e85",
           "314120e5-87bf-4791-80ae-cd443fad4186",
           "4719e386-5f75-42ec-9fb2-91f8386f9f87",
+          "317ab59f-2379-451a-9fbc-c397fd31dd5c",
           "873403fc-c264-4f6b-86ae-092abee2a1d0",
           "37fc6d23-1902-4172-ab24-1c0cd8eab5b7",
           "f591c362-5976-4efe-aca1-f1c0cb9f31af",
@@ -521,6 +522,7 @@
           "y": 410
         },
         "z": 0,
+        "parent": "a487cf69-e5ce-4956-85df-761e6427deef",
         "embeds": []
       },
       "ba5ed5e4-dbc6-46d0-99b6-11844d72790b": {
@@ -819,7 +821,8 @@
         "z": 0,
         "embeds": [],
         "isconnectedto": [
-          "f591c362-5976-4efe-aca1-f1c0cb9f31af"
+          "f591c362-5976-4efe-aca1-f1c0cb9f31af",
+          "1bbd2641-5532-431b-a1dd-a7dd893e58db"
         ],
         "isassociatedwith": [
           "428b2995-219a-422e-a4b6-bc7c91ff2828"
@@ -837,7 +840,8 @@
         "z": 0,
         "embeds": [],
         "ismemberof": [
-          "4382883d-ccbb-4b33-934c-19e73f682e7f"
+          "4382883d-ccbb-4b33-934c-19e73f682e7f",
+          "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0"
         ],
         "isrelatedto": [
           "f77c932d-e2ff-48ee-b941-decf296031a5",
@@ -882,13 +886,13 @@
           "id": "251f6d10-84e4-44a1-b93e-67bbe9078fba"
         },
         "target": {
-          "id": "4382883d-ccbb-4b33-934c-19e73f682e7f"
+          "id": "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0"
         },
         "z": 0
       },
       "9fca00aa-30f9-4b28-9fdc-5459f77dabc2": {
         "source": {
-          "id": "4382883d-ccbb-4b33-934c-19e73f682e7f"
+          "id": "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0"
         },
         "target": {
           "id": "4719e386-5f75-42ec-9fb2-91f8386f9f87"
@@ -957,6 +961,90 @@
         },
         "target": {
           "id": "b0f95c49-7207-4b33-b319-226f6653b599"
+        },
+        "z": 11
+      },
+      "1bbd2641-5532-431b-a1dd-a7dd893e58db": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": -280,
+          "y": 450
+        },
+        "z": 0,
+        "embeds": [],
+        "isconnectedto": [
+          "f591c362-5976-4efe-aca1-f1c0cb9f31af",
+          "314120e5-87bf-4791-80ae-cd443fad4186"
+        ],
+        "ismemberof": [
+          "317ab59f-2379-451a-9fbc-c397fd31dd5c",
+          "1cc85fdc-e298-4914-849e-7a7f18364e85"
+        ]
+      },
+      "1cc85fdc-e298-4914-849e-7a7f18364e85": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": -280,
+          "y": 350
+        },
+        "z": 0,
+        "parent": "a487cf69-e5ce-4956-85df-761e6427deef",
+        "embeds": []
+      },
+      "69e0901d-92ad-4175-b3f2-1f6618904efe": {
+        "source": {
+          "id": "4cd01314-51ae-4fac-9c95-36004183543b"
+        },
+        "target": {
+          "id": "1cc85fdc-e298-4914-849e-7a7f18364e85"
+        },
+        "z": 0
+      },
+      "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0": {
+        "size": {
+          "width": 60,
+          "height": 60
+        },
+        "position": {
+          "x": -1310,
+          "y": 1010
+        },
+        "z": 0,
+        "embeds": []
+      },
+      "0f5edb47-7f6a-4725-8040-c57418252862": {
+        "source": {
+          "id": "428b2995-219a-422e-a4b6-bc7c91ff2828"
+        },
+        "target": {
+          "id": "9837f252-8e6b-4d4a-8f3c-2d7fd5fad8d0"
+        },
+        "z": 11
+      },
+      "d200f8d6-f4af-4375-aa84-7f0cad42b8e0": {
+        "source": {
+          "id": "428b2995-219a-422e-a4b6-bc7c91ff2828",
+          "selector": "g:nth-child(1) g:nth-child(4) g:nth-child(2) circle:nth-child(1)     ",
+          "port": "AWS::MembershipLInk-AWS::EC2::SecurityGroup-SecurityGroups"
+        },
+        "target": {
+          "x": -1270,
+          "y": 1040
+        },
+        "z": 12
+      },
+      "66c123bc-6da7-4b72-9545-641dbd6dc413": {
+        "source": {
+          "id": "709e8f08-6b1d-4ca0-ab00-1d1486528d41"
+        },
+        "target": {
+          "id": "1bbd2641-5532-431b-a1dd-a7dd893e58db"
         },
         "z": 11
       }
@@ -2268,6 +2356,11 @@
           {
             "Ref": "ControllerSubnet"
           }
+        ],
+        "LoadBalancerNames": [
+          {
+            "Ref": "GatewayLoadBalancer"
+          }
         ]
       },
       "Metadata": {
@@ -2447,6 +2540,82 @@
       "Metadata": {
         "AWS::CloudFormation::Designer": {
           "id": "b0f95c49-7207-4b33-b319-226f6653b599"
+        }
+      }
+    },
+    "GatewayLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "Subnets": [
+          {
+            "Ref": "PublicSubnet"
+          }
+        ],
+        "SecurityGroups": [
+          {
+            "Ref": "GatewayLoadBalancerSecurityGroup"
+          }
+        ],
+        "Listeners": [
+          {
+            "InstancePort": 7331,
+            "InstanceProtocol": "TCP",
+            "LoadBalancerPort": 80,
+            "Protocol": "TCP"
+          }
+        ],
+        "HealthCheck": {
+          "Target": "TCP:7331",
+          "HealthyThreshold": "2",
+          "Interval": "6",
+          "Timeout": "5",
+          "UnhealthyThreshold": "2"
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "1bbd2641-5532-431b-a1dd-a7dd893e58db"
+        }
+      }
+    },
+    "ControllerSecurityGroupIngressFromGatewayLoadBalancer": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "ControllerSecurityGroup"
+        },
+        "SourceSecurityGroupId": {
+          "Ref": "GatewayLoadBalancerSecurityGroup"
+        },
+        "FromPort": 7331,
+        "ToPort": 7331,
+        "IpProtocol": "TCP"
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "69e0901d-92ad-4175-b3f2-1f6618904efe"
+        }
+      }
+    },
+    "GatewayLoadBalancerSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "GatewayLoadBalancerSecurityGroup",
+        "VpcId": {
+          "Ref": "ClusterVPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "TCP",
+            "FromPort": 443,
+            "ToPort": 443,
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "1cc85fdc-e298-4914-849e-7a7f18364e85"
         }
       }
     }

--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -1115,7 +1115,7 @@
         ],
         "LoadBalancerNames": [
           {
-            "Ref": "ControllerLoadBalancer"
+            "Ref": "ControllerPublicELB"
           }
         ],
         "VPCZoneIdentifier": [
@@ -1504,14 +1504,14 @@
         }
       }
     },
-    "ControllerSecurityGroupIngressLoadBalancerToAPI": {
+    "ControllerSecurityGroupIngressELBToAPI": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": {
           "Ref": "ControllerSecurityGroup"
         },
         "SourceSecurityGroupId": {
-          "Ref": "ControllerLoadBalancerSecurityGroup"
+          "Ref": "ControllerPublicELBSecurityGroup"
         },
         "FromPort": 6443,
         "ToPort": 6443,
@@ -1952,7 +1952,7 @@
         }
       }
     },
-    "ControllerLoadBalancer": {
+    "ControllerPublicELB": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "Subnets": [
@@ -1962,7 +1962,7 @@
         ],
         "SecurityGroups": [
           {
-            "Ref": "ControllerLoadBalancerSecurityGroup"
+            "Ref": "ControllerPublicELBSecurityGroup"
           }
         ],
         "Listeners": [
@@ -1987,10 +1987,10 @@
         }
       }
     },
-    "ControllerLoadBalancerSecurityGroup": {
+    "ControllerPublicELBSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "ControllerLoadBalancerSecurityGroup",
+        "GroupDescription": "ControllerPublicELBSecurityGroup",
         "VpcId": {
           "Ref": "ClusterVPC"
         },
@@ -2009,7 +2009,7 @@
         }
       }
     },
-    "ControllerLoadBalancerDNSRecord": {
+    "ControllerPublicELBDNSRecord": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
@@ -2040,7 +2040,7 @@
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
-              "ControllerLoadBalancer",
+              "ControllerPublicELB",
               "DNSName"
             ]
           }
@@ -2359,7 +2359,7 @@
         ],
         "LoadBalancerNames": [
           {
-            "Ref": "GatewayLoadBalancer"
+            "Ref": "GatewayPublicELB"
           }
         ]
       },
@@ -2543,7 +2543,7 @@
         }
       }
     },
-    "GatewayLoadBalancer": {
+    "GatewayPublicELB": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
         "Subnets": [
@@ -2553,7 +2553,7 @@
         ],
         "SecurityGroups": [
           {
-            "Ref": "GatewayLoadBalancerSecurityGroup"
+            "Ref": "GatewayPublicELBSecurityGroup"
           }
         ],
         "Listeners": [
@@ -2578,14 +2578,14 @@
         }
       }
     },
-    "ControllerSecurityGroupIngressFromGatewayLoadBalancer": {
+    "ControllerSecurityGroupIngressFromGatewayPublicELB": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": {
           "Ref": "ControllerSecurityGroup"
         },
         "SourceSecurityGroupId": {
-          "Ref": "GatewayLoadBalancerSecurityGroup"
+          "Ref": "GatewayPublicELBSecurityGroup"
         },
         "FromPort": 7331,
         "ToPort": 7331,
@@ -2597,10 +2597,10 @@
         }
       }
     },
-    "GatewayLoadBalancerSecurityGroup": {
+    "GatewayPublicELBSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "GatewayLoadBalancerSecurityGroup",
+        "GroupDescription": "GatewayPublicELBSecurityGroup",
         "VpcId": {
           "Ref": "ClusterVPC"
         },

--- a/roles/kube-gateway/vars/main.yml
+++ b/roles/kube-gateway/vars/main.yml
@@ -2,4 +2,4 @@ apiserver_secure_port: 6443
 apiserver_insecure_port: 8080
 apiserver_local_endpoint: "http://127.0.0.1:{{ apiserver_insecure_port }}"
 
-farva_image: "quay.io/bcwaldon/farva:e17e33121b9f1619ced6a24f5be9debc0ae444d4"
+farva_image: "quay.io/bcwaldon/farva:e72d0f32feed2d62f43b1b8b0e33efeb2196d512"


### PR DESCRIPTION
The static port 7331 on the gateways will be used by farva for all ingress traffic. Waiting on corresponding PR from @jacobstr 
