### PR TITLE
Adding a gateway label to select gateway pods.

### DIFF
--- a/roles/kube-gateway/templates/gateway.yml.j2
+++ b/roles/kube-gateway/templates/gateway.yml.j2
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: gateway
+  labels:
+    app: gateway
   namespace: kube-system
 spec:
   hostNetwork: true


### PR DESCRIPTION
This allows the following to work:

  kubectl get pods --all-namespaces -l app=gateway
