### PR TITLE
Tuning GatewayELB and security group config.

### DIFF
--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -2722,8 +2722,8 @@
         "SecurityGroupIngress": [
           {
             "IpProtocol": "TCP",
-            "FromPort": 443,
-            "ToPort": 443,
+            "FromPort": 80,
+            "ToPort": 80,
             "CidrIp": "0.0.0.0/0"
           }
         ]


### PR DESCRIPTION
We've set the load balancer to listen only on port 80, at the same time
our GatewayPublicELBSecurityGroup only allows traffic on 443.
