### PR TITLE
Route public traffic to gateway port 7330

### DIFF
--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -2673,14 +2673,14 @@
         ],
         "Listeners": [
           {
-            "InstancePort": 7331,
+            "InstancePort": 7330,
             "InstanceProtocol": "TCP",
             "LoadBalancerPort": 80,
             "Protocol": "TCP"
           }
         ],
         "HealthCheck": {
-          "Target": "TCP:7331",
+          "Target": "TCP:7330",
           "HealthyThreshold": "2",
           "Interval": "6",
           "Timeout": "5",
@@ -2702,8 +2702,8 @@
         "SourceSecurityGroupId": {
           "Ref": "GatewayPublicELBSecurityGroup"
         },
-        "FromPort": 7331,
-        "ToPort": 7331,
+        "FromPort": 7330,
+        "ToPort": 7330,
         "IpProtocol": "TCP"
       },
       "Metadata": {


### PR DESCRIPTION
farva will eventually serve traffic on port 7330 for services
that are intended to be exposed on the public internet. farva
does not currently do this, so this is effectively a NOP.
