### PR TITLE
Updating farva to use smart reloading.

### DIFF
--- a/roles/kube-gateway/vars/main.yml
+++ b/roles/kube-gateway/vars/main.yml
@@ -2,4 +2,4 @@ apiserver_secure_port: 6443
 apiserver_insecure_port: 8080
 apiserver_local_endpoint: "http://127.0.0.1:{{ apiserver_insecure_port }}"
 
-farva_image: "quay.io/bcwaldon/farva:0c936106e411802ba6bfc7d1c9030dd332530c2f"
+farva_image: "quay.io/bcwaldon/farva:b61d171ee1b20f8c19f59935cb52e45c400dc218"


### PR DESCRIPTION
This version of farva only reloads nginx when the configuration has changed.
The intent here was to avoid unncessary connection draining / blips when
nginx needs to reload. See:
https://github.com/bcwaldon/farva/commit/b61d171ee1b20f8c19f59935cb52e45c400dc218
