### PR TITLE
Omit wrapping on linux when base64 encoding

### DIFF
--- a/roles/configure/templates/create-stack.sh.j2
+++ b/roles/configure/templates/create-stack.sh.j2
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
-USER_DATA=$(cat {{ cluster_dir }}/cloud-config.yml | base64)
-BASTION_USER_DATA=$(cat {{ cluster_dir }}/bastion-cloud-config.yml | base64)
-AGGREGATOR_USER_DATA=$(cat {{ cluster_dir }}/aggregator-cloud-config.yml | base64)
+[[ "$OSTYPE" = "linux-gnu" ]] && BASE64ARGS="-w0" 
+
+USER_DATA=$(cat {{ cluster_dir }}/cloud-config.yml | base64 $BASE64ARGS)
+BASTION_USER_DATA=$(cat {{ cluster_dir }}/bastion-cloud-config.yml | base64 $BASE64ARGS)
+AGGREGATOR_USER_DATA=$(cat {{ cluster_dir }}/aggregator-cloud-config.yml | base64 $BASE64ARGS)
 
 PARAMETERS=( 
 	"ParameterKey=PeerVPC,ParameterValue={{ peer_vpc_id }}"


### PR DESCRIPTION
coreutils' base64 utility will wrap base64 output by default, this disables the wrapping so that newlines don't mess up the rest of the script.
