### PR TITLE
Tag WorkerSubnet for internal ELBs.

### DIFF
--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -1876,7 +1876,7 @@
           {
             "Key": "kubernetes.io/role/internal-elb",
             "Value": {
-              "Ref": "true"
+              "Value": "true"
             }
           }
         ]

--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -1875,9 +1875,7 @@
           },
           {
             "Key": "kubernetes.io/role/internal-elb",
-            "Value": {
-              "Value": "true"
-            }
+            "Value": "true"
           }
         ]
       },

--- a/roles/configure/files/stack-template.json
+++ b/roles/configure/files/stack-template.json
@@ -1865,7 +1865,21 @@
         "MapPublicIpOnLaunch": false,
         "AvailabilityZone": {
           "Ref": "AvailabilityZone"
-        }
+        },
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": {
+              "Ref": "ClusterName"
+            }
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": {
+              "Ref": "true"
+            }
+          }
+        ]
       },
       "Metadata": {
         "AWS::CloudFormation::Designer": {


### PR DESCRIPTION
When using the `service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0` annotation, the internal ELB was getting placed on the public subnet. Setting these tags allows it to find the internal subnet of the worker nodes.
