### PR TITLE
Add kubernetes_log_verbose flag to cluster config

### DIFF
--- a/contrib/main.yml.sample
+++ b/contrib/main.yml.sample
@@ -268,3 +268,7 @@ logspout_enabled: false
 # server where logspout should send its logs. This field is only used if
 # logspout_enabled is true.
 #logspout_syslog_host:
+
+# kubernetes_log_verbose controls whether or not the Kubernetes components
+# log at a high level of verbosity or not.
+kubernetes_log_verbose: false

--- a/roles/kube-controller/templates/kube-apiserver.yml.j2
+++ b/roles/kube-controller/templates/kube-apiserver.yml.j2
@@ -15,7 +15,9 @@ spec:
     - "--etcd-servers={{ etcd_client_endpoint }}"
     - "--advertise-address={{ ec2_private_ip_address }}"
     - "--service-cluster-ip-range={{ cluster_service_network_cidr }}"
+{% if kubernetes_log_verbose %}
     - "--v=2"
+{% endif %}
     - "--client-ca-file=/etc/kubernetes/ca.pem"
     - "--tls-cert-file=/etc/kubernetes/apiserver.pem"
     - "--tls-private-key-file=/etc/kubernetes/apiserver-key.pem"

--- a/roles/kube-controller/templates/kube-controller-manager.yml.j2
+++ b/roles/kube-controller/templates/kube-controller-manager.yml.j2
@@ -12,7 +12,9 @@ spec:
     - "/hyperkube"
     - "controller-manager"
     - "--master={{ apiserver_local_endpoint }}"
+{% if kubernetes_log_verbose %}
     - "--v=2"
+{% endif %}
     - "--root-ca-file=/etc/kubernetes/ca.pem"
     - "--service-account-private-key-file=/etc/kubernetes/apiserver-key.pem"
     - "--cloud-provider=aws"

--- a/roles/kube-controller/templates/kube-scheduler.yml.j2
+++ b/roles/kube-controller/templates/kube-scheduler.yml.j2
@@ -12,5 +12,7 @@ spec:
     - "/hyperkube"
     - "scheduler"
     - "--master={{ apiserver_local_endpoint }}"
+{% if kubernetes_log_verbose %}
     - "--v=2"
+{% endif %}
     - "--leader-elect=true"

--- a/roles/kubelet/templates/kube-proxy.yml.j2
+++ b/roles/kubelet/templates/kube-proxy.yml.j2
@@ -11,7 +11,9 @@ spec:
     args:
     - "/hyperkube"
     - "proxy"
+{% if kubernetes_log_verbose %}
     - "--v=2"
+{% endif %}
     - "--proxy-mode=iptables"
     - "--bind-address={{ ec2_private_ip_address }}"
     - "--hostname-override={{ ec2_id }}"

--- a/roles/kubelet/templates/kubelet.env.j2
+++ b/roles/kubelet/templates/kubelet.env.j2
@@ -1,7 +1,9 @@
 KUBELET_VERSION={{ kubelet_version }}
 
 KUBELET_OPTS= \
+{% if kubernetes_log_verbose %}
 --v=2 \
+{% endif %}
 --config=/etc/kubernetes/manifests \
 --allow-privileged=true \
 --address=0.0.0.0 \


### PR DESCRIPTION
Set the default to false, which means verbose logs are not enabled by
default. Users can set this to true to re-enable verbose logs. This is a
required option.
