### PR TITLE
Configurable max body size and 10m default.

### DIFF
--- a/src/farva/cmd/farva-gateway/main.go
+++ b/src/farva/cmd/farva-gateway/main.go
@@ -33,6 +33,7 @@ func main() {
 	fs.StringVar(&cfg.KubeconfigFile, "kubeconfig", "", "Set this to provide an explicit path to a kubeconfig, otherwise the in-cluster config will be used.")
 	fs.BoolVar(&cfg.NGINXDryRun, "nginx-dry-run", false, "Log nginx management commands rather than executing them.")
 	fs.IntVar(&cfg.NGINXHealthPort, "nginx-health-port", gateway.DefaultNGINXConfig.HealthPort, "Port to listen on for nginx health checks.")
+	fs.StringVar(&cfg.NGINXMaxBodySize, "nginx-max-body-size", gateway.DefaultNGINXConfig.MaxBodySize, "Global default max body size for incoming requests.")
 	fs.IntVar(&cfg.FarvaHealthPort, "farva-health-port", gateway.DefaultConfig.FarvaHealthPort, "Port to listen on for farva health checks.")
 	fs.IntVar(&cfg.HTTPListenPort, "http-listen-port", gateway.DefaultConfig.HTTPListenPort, "Port to listen on for HTTP traffic.")
 	fs.StringVar(&cfg.FifoPath, "fifo-path", gateway.DefaultConfig.FifoPath, "Location of nginx stderr and stdout logging fifo.")

--- a/src/farva/pkg/gateway/reverseproxy_nginx.go
+++ b/src/farva/pkg/gateway/reverseproxy_nginx.go
@@ -32,6 +32,8 @@ error_log {{ .NGINXConfig.ErrorLog }};
 daemon on;
 worker_processes auto;
 
+client_max_body_size {{ .NGINXConfig.MaxBodySize }};
+
 events {
     worker_connections 512;
 }
@@ -133,6 +135,7 @@ stream {
 		HealthPort:  7332,
 		AccessLog:   "/dev/stdout",
 		ErrorLog:    "/dev/stderr",
+		MaxBodySize: "10m",
 	}
 )
 
@@ -150,6 +153,7 @@ type NGINXConfig struct {
 	ListenPort  int
 	ErrorLog    string
 	AccessLog   string
+	MaxBodySize string
 }
 
 func newNGINXConfig(hp int, cz string, errorLog string, accessLog string) NGINXConfig {

--- a/src/farva/pkg/gateway/reverseproxy_nginx_test.go
+++ b/src/farva/pkg/gateway/reverseproxy_nginx_test.go
@@ -55,6 +55,8 @@ error_log /dev/stderr;
 daemon on;
 worker_processes auto;
 
+client_max_body_size 10m;
+
 events {
     worker_connections 512;
 }
@@ -150,6 +152,8 @@ pid /var/run/nginx.pid;
 error_log /dev/stderr;
 daemon on;
 worker_processes auto;
+
+client_max_body_size 10m;
 
 events {
     worker_connections 512;
@@ -281,6 +285,8 @@ error_log /dev/stderr;
 daemon on;
 worker_processes auto;
 
+client_max_body_size 10m;
+
 events {
     worker_connections 512;
 }
@@ -411,6 +417,8 @@ error_log /dev/stderr;
 daemon on;
 worker_processes auto;
 
+client_max_body_size 10m;
+
 events {
     worker_connections 512;
 }
@@ -488,6 +496,8 @@ error_log /dev/stderr;
 daemon on;
 worker_processes auto;
 
+client_max_body_size 10m;
+
 events {
     worker_connections 512;
 }
@@ -560,6 +570,8 @@ pid /var/run/nginx.pid;
 error_log /dev/stderr;
 daemon on;
 worker_processes auto;
+
+client_max_body_size 10m;
 
 events {
     worker_connections 512;
@@ -638,6 +650,8 @@ pid /var/run/nginx.pid;
 error_log /dev/stderr;
 daemon on;
 worker_processes auto;
+
+client_max_body_size 10m;
 
 events {
     worker_connections 512;


### PR DESCRIPTION
Some users in a klondike cluster may not want to be limited to 1mb requests
which is the nginx default.

This corresponds to the PR In the public repo: https://github.com/planetlabs/klondike/pull/2